### PR TITLE
Remove validation requiring PRs to have a body/title

### DIFF
--- a/__tests__/parseGithubLabelEvent.test.ts
+++ b/__tests__/parseGithubLabelEvent.test.ts
@@ -1,4 +1,4 @@
-import {parseGithubLabelEvent} from '../src/types/githubEvent';
+import { parseGithubLabelEvent } from '../src/types/githubEvent';
 
 const input = `{
   "action": "labeled",
@@ -34,8 +34,50 @@ const input = `{
   }
 }`;
 
+const input_no_pr_title_body = `{
+  "action": "unlabeled",
+  "label": {
+    "color": "d73a4a",
+    "default": true,
+    "description": "Something isn't working",
+    "id": 5209427085,
+    "name": "bug",
+    "url": "https://api.github.com/repos/thefuntastic/actions_test/labels/bug"
+  },
+  "pull_request": {
+    "body": null,
+    "id": 123456,
+    "labels": [
+      {
+        "color": "d73a4a",
+        "default": true,
+        "description": "Something isn't working",
+        "id": 5209427085,
+        "name": "bug",
+        "url": "https://api.github.com/repos/thefuntastic/actions_test/labels/bug"
+      }
+    ],
+    "number": 1,
+    "title": null
+  },
+  "repository": {
+    "name": "actions_test",
+    "owner": {
+      "login": "thefuntastic"
+    }
+  }
+}`;
+
 test('Postive case', () => {
   const data = parseGithubLabelEvent(input);
 
   expect(data.action).toEqual('labeled');
+});
+
+
+test('Test no title/body', () => {
+  //PR without title or body will be caught by the octobors rules, don't need to filter here
+  const data = parseGithubLabelEvent(input_no_pr_title_body);
+
+  expect(data.action).toEqual('unlabeled');
 });

--- a/src/types/githubEvent.ts
+++ b/src/types/githubEvent.ts
@@ -54,8 +54,6 @@ function isGithubLabelEvent(event: unknown): event is GithubLabelEvent {
     typeof labelEvent.repository.owner.login === 'string' &&
     typeof labelEvent.pull_request === 'object' &&
     typeof labelEvent.pull_request.number === 'number' &&
-    typeof labelEvent.pull_request.title === 'string' &&
-    typeof labelEvent.pull_request.body === 'string' &&
     Array.isArray(labelEvent.pull_request.labels)
   );
 }


### PR DESCRIPTION
Octobors rules will already prevent PRs without a description from being merged. Repeating that validation here leads to the action failing (and showing red in CI status). 

With the new change, the embark bot will instead positively review the PR when the `skip review` label is applied and there is no PR body. The merge bot (responsibility of octobors, not this action) itself then won't merge the PR until it's satisfied the PR has a description provided. 